### PR TITLE
Bump OpenCV version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geocoder==1.38.1
 imutils==0.5.3
 numpy==1.19.5
-opencv_python==3.4.8.29
+opencv_python==4.8.0.76
 pandas==1.0.1
 Pillow==7.0.0
 pyephem==3.7.7.0


### PR DESCRIPTION
Version 3.4.8.29 has a [few bugs ](https://github.com/CMU-Perceptual-Computing-Lab/openpose/issues/2226)with OBS virtual camera, which some people may use to insert a piggybacked guide camera into the software if their camera does not support an HDMI output while recording (I found this out the hard way while waiting on my HDMI capture card). From my testing, bumping it did not introduce any bugs.